### PR TITLE
Gruppering vedlegg

### DIFF
--- a/src/components/dokumentliste/CreateListElement.tsx
+++ b/src/components/dokumentliste/CreateListElement.tsx
@@ -21,7 +21,7 @@ export interface journalposterProps {
       brukerHarTilgang: boolean;
       eventuelleGrunnerTilManglendeTilgang: Array<string>;
       variant: string;
-    }
+    },
   ];
   harVedlegg: boolean;
 }
@@ -39,7 +39,7 @@ export const CreateListElement = (journalpost: journalposterProps, language: Tex
   const hasVedlegg = journalpost.dokumenter.length > 1;
 
   return (
-    <li key={Math.random()}>
+    <li key={journalpost.journalpostId}>
       <Dokument
         dokument={journalpost.dokumenter[0]}
         innsender={innsender}

--- a/src/components/dokumentliste/Vedlegg.module.css
+++ b/src/components/dokumentliste/Vedlegg.module.css
@@ -23,7 +23,6 @@
   text-decoration: none;
   padding: 0.75rem;
   padding-left: 4rem;
-
 }
 
 .veddleggsListe {
@@ -37,4 +36,26 @@
   padding-bottom: 0.5rem;
   font-size: 1rem;
   font-weight: 600;
+}
+
+.btn {
+  margin-left: 4rem;
+}
+
+.chevron {
+  overflow: visible;
+}
+
+.show {
+  display: flex;
+}
+
+.visuallyHidden:not(:focus):not(:active) {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }

--- a/src/components/dokumentliste/Vedlegg.tsx
+++ b/src/components/dokumentliste/Vedlegg.tsx
@@ -49,7 +49,7 @@ const Vedlegg = ({ dokumenter, language, baseUrl }: Props) => {
         <Button
           className={styles.btn}
           variant="secondary-neutral"
-          size="small"
+          size="xsmall"
           icon={<ChevronDownIcon fontSize="1.5rem" aria-hidden />}
           onClick={() => handleOnClick()}
         >

--- a/src/components/dokumentliste/Vedlegg.tsx
+++ b/src/components/dokumentliste/Vedlegg.tsx
@@ -1,9 +1,10 @@
-import { EyeSlashIcon, PaperclipIcon } from "@navikt/aksel-icons";
-import styles from "./Vedlegg.module.css";
-import { dokumentProps } from "./Dokument";
-import { BodyShort } from "@navikt/ds-react";
+import { ChevronDownIcon, EyeSlashIcon, PaperclipIcon } from "@navikt/aksel-icons";
+import { BodyShort, Button } from "@navikt/ds-react";
+import { useState } from "react";
 import { TextLanguages, text } from "../../language/text";
 import { logNavigereEvent } from "../../utils/amplitude";
+import { dokumentProps } from "./Dokument";
+import styles from "./Vedlegg.module.css";
 
 interface Props {
   dokumenter: Array<dokumentProps>;
@@ -18,8 +19,14 @@ interface VedleggslenkeProps {
 }
 
 const Vedlegg = ({ dokumenter, language, baseUrl }: Props) => {
+  const [hideVedlegg, setHideVedlegg] = useState(true);
   const antallVedlegg = dokumenter.length - 1;
   const vedleggsListe = dokumenter.filter((d) => d.dokumenttype === "VEDLEGG");
+  const grupperVedlegg = antallVedlegg > 1;
+
+  const handleOnClick = () => {
+    setHideVedlegg(!hideVedlegg);
+  };
 
   const VedleggsLenke = ({ url, tittel, brukerHarTilgang }: VedleggslenkeProps) => {
     return brukerHarTilgang ? (
@@ -34,6 +41,33 @@ const Vedlegg = ({ dokumenter, language, baseUrl }: Props) => {
       </div>
     );
   };
+
+  if (grupperVedlegg) {
+    return (
+      <div className={styles.veddleggsListe}>
+        <BodyShort className={styles.tittel}>{text.antallVedlegg[language](antallVedlegg)}</BodyShort>
+        <Button
+          className={styles.btn}
+          variant="secondary-neutral"
+          size="small"
+          icon={<ChevronDownIcon fontSize="1.5rem" aria-hidden />}
+          onClick={() => handleOnClick()}
+        >
+          {text.visVedlegg[language]}
+        </Button>
+        <div className={hideVedlegg ? styles.visuallyHidden : null}>
+          {vedleggsListe.map((vedlegg: dokumentProps) => (
+            <VedleggsLenke
+              url={`${baseUrl}/${vedlegg.dokumentInfoId}`}
+              tittel={vedlegg.tittel}
+              brukerHarTilgang={vedlegg.brukerHarTilgang}
+              key={vedlegg.dokumentInfoId}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.veddleggsListe}>

--- a/src/components/dokumentliste/Vedlegg.tsx
+++ b/src/components/dokumentliste/Vedlegg.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, EyeSlashIcon, PaperclipIcon } from "@navikt/aksel-icons";
+import { ChevronDownIcon, ChevronUpIcon, EyeSlashIcon, PaperclipIcon } from "@navikt/aksel-icons";
 import { BodyShort, Button } from "@navikt/ds-react";
 import { useState } from "react";
 import { TextLanguages, text } from "../../language/text";
@@ -50,10 +50,16 @@ const Vedlegg = ({ dokumenter, language, baseUrl }: Props) => {
           className={styles.btn}
           variant="secondary-neutral"
           size="xsmall"
-          icon={<ChevronDownIcon fontSize="1.5rem" aria-hidden />}
+          icon={
+            hideVedlegg ? (
+              <ChevronDownIcon fontSize="1.5rem" aria-hidden />
+            ) : (
+              <ChevronUpIcon fontSize="1.5rem" aria-hidden />
+            )
+          }
           onClick={() => handleOnClick()}
         >
-          {text.visVedlegg[language]}
+          {hideVedlegg ? text.visVedlegg[language] : text.skjulVedlegg[language]}
         </Button>
         <div className={hideVedlegg ? styles.visuallyHidden : null}>
           {vedleggsListe.map((vedlegg: dokumentProps) => (

--- a/src/language/text.ts
+++ b/src/language/text.ts
@@ -1,8 +1,8 @@
 type Languages = {
-  nb: string,
-  nn: string,
-  en: string,
-}
+  nb: string;
+  nn: string;
+  en: string;
+};
 
 export type TextLanguages = keyof Languages;
 
@@ -231,5 +231,10 @@ export const text = {
     nb: "Ditt sykefravær",
     nn: "Ditt sjukefravær",
     en: "Sickness benefit",
+  },
+  visVedlegg: {
+    nb: "Vis vedlegg",
+    nn: "Vis vedlegg",
+    en: "Show attachments",
   },
 };

--- a/src/language/text.ts
+++ b/src/language/text.ts
@@ -237,4 +237,9 @@ export const text = {
     nn: "Vis vedlegg",
     en: "Show attachments",
   },
+  skjulVedlegg: {
+    nb: "Skjul vedlegg",
+    nn: "Skjul vedlegg",
+    en: "Hide attachments",
+  },
 };


### PR DESCRIPTION
Lagt til knapp som dokumentarkivet nå visuelt skjuler vedlegg bak hvis det er mer enn ett vedlegg per dokument/journalpost. 

UU-funksjonalitet slik at vedleggene ikke skjules for skjermlesere / fjernes fra DOM.