### PR TITLE
Fjernet nynorsk som valg i språkvelger

### DIFF
--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -15,7 +15,7 @@ const setDocumentLanguage = (language: Locale) => {
 const updateState = (newLanguage: Locale, currentLanguage: Locale) => {
   const replacementUrl = window.location.href.replace(
     baseUrlWithLanguage[currentLanguage],
-    baseUrlWithLanguage[newLanguage]
+    baseUrlWithLanguage[newLanguage],
   );
   window.history.replaceState(window.history.state, "", replacementUrl);
 };
@@ -39,10 +39,6 @@ export const useLanguage = () => {
       },
       {
         locale: "en",
-        handleInApp: true,
-      },
-      {
-        locale: "nn",
         handleInApp: true,
       },
     ]);


### PR DESCRIPTION
Mangler oversettelser til nynorsk, så fjerner nynorsk valget fra språkvelger fram til oversettelser er på plass