### PR TITLE
Forbedre autentiseringsjekk

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import DokumentUtlisting from "./components/pages/dokumentutlisting/DokumentUtli
 import Landingsside from "./components/pages/landingsside/Landingsside";
 import { useLanguage } from "./hooks/useLanguage";
 import { initializeAmplitude } from "./utils/amplitude";
+import { reloadOnPageshow } from "./utils/reloadContentOnPageshow.ts";
 
 const App = () => {
   const BASEPATH = "/dokumentarkiv";
@@ -11,6 +12,7 @@ const App = () => {
 
   useLanguage();
   initializeAmplitude();
+  reloadOnPageshow();
 
   return (
     <main className={styles.pageContainer}>

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,8 +1,10 @@
-import { postUserUrl } from "../urls";
+import { dokumentArkivUrl, postUserUrl } from "../urls";
+import { redirectToIdPorten, redirectToLandingsside } from "./redirect.ts";
 
 interface Props {
   path: string;
   options?: object;
+  handleNotFound?: boolean;
   eventObj?: object;
 }
 
@@ -14,7 +16,7 @@ export const include = {
   credentials: "include",
 };
 
-export const fetcher = async ({ path, options }: Props) => {
+export const fetcher = async ({ path, options, handleNotFound }: Props) => {
   const response = await fetch(path, {
     method: "GET",
     credentials: "include",
@@ -22,21 +24,28 @@ export const fetcher = async ({ path, options }: Props) => {
   });
 
   if (!response.ok) {
+    if (response.status === 401) {
+      redirectToIdPorten(`${dokumentArkivUrl}`);
+    }
+    if (handleNotFound && response.status === 404) {
+      redirectToLandingsside();
+    }
+
     throw new Error("Fetch request failed");
   }
 
   return await response.json();
 };
 
-export const postUser = async (ident : eventObjectProps) => {
+export const postUser = async (ident: eventObjectProps) => {
   const response = await fetch(postUserUrl, {
     method: "POST",
     credentials: "include",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(ident),
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(ident),
   });
 
   if (!response.ok) {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,8 +26,7 @@ export const fetcher = async ({ path, options, handleNotFound }: Props) => {
   if (!response.ok) {
     if (response.status === 401) {
       redirectToIdPorten(`${dokumentArkivUrl}`);
-    }
-    if (handleNotFound && response.status === 404) {
+    } else if (handleNotFound && response.status === 404) {
       redirectToLandingsside();
     }
 

--- a/src/api/redirect.ts
+++ b/src/api/redirect.ts
@@ -1,7 +1,9 @@
-import { mineSakerApiUrl } from "../urls";
+import { dokumentArkivUrl, mineSakerApiUrl } from "../urls";
 
-const redirectToIdPorten = (redirectUrl: string) => {
+export const redirectToIdPorten = (redirectUrl: string) => {
   window.location.assign(`${mineSakerApiUrl}/login?level=Level4&redirect_uri=${redirectUrl}${window.location.search}`);
 };
 
-export default redirectToIdPorten;
+export const redirectToLandingsside = () => {
+  window.location.assign(dokumentArkivUrl);
+};

--- a/src/components/authentication/Authentication.tsx
+++ b/src/components/authentication/Authentication.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { fetcher, include } from "../../api/api";
-import redirectToIdPorten from "../../api/redirect";
+import { redirectToIdPorten } from "../../api/redirect";
 import { authenticationUrl } from "../../urls";
 import ContentLoader from "../loader/ContentLoader";
-import useSWR from "swr";
+import useSWRImmutable from "swr/immutable";
 
 type Props = {
   children?: React.ReactNode;
@@ -16,7 +16,7 @@ interface AuthenticationProps {
 }
 
 const Authentication = ({ children }: Props) => {
-  const { data, isLoading, error } = useSWR<AuthenticationProps>(
+  const { data, isLoading, error } = useSWRImmutable<AuthenticationProps>(
     { path: authenticationUrl, options: include },
     fetcher,
     {

--- a/src/components/dokumentliste/Dokumentliste.tsx
+++ b/src/components/dokumentliste/Dokumentliste.tsx
@@ -18,12 +18,12 @@ const Dokumentliste = () => {
     : `${mineSakerApiUrl}/sakstema/${temakode}/journalposter`;
 
   const { data: journalpostListe, isLoading } = useSWRImmutable<DokumentlisteProps>(
-    { path: journalposterUrl },
+    { path: journalposterUrl, handleNotFound: true },
     fetcher,
     {
       shouldRetryOnError: false,
       onError: setIsError,
-    },
+    }
   );
 
   const language = useStore(languageAtom);

--- a/src/components/pages/dokumentutlisting/DokumentUtlisting.tsx
+++ b/src/components/pages/dokumentutlisting/DokumentUtlisting.tsx
@@ -29,10 +29,14 @@ const DokumentUtlisting = () => {
     ? `${mineSakerApiUrl}/sakstema/${temakode}/journalpost/${journalpostId}`
     : `${mineSakerApiUrl}/sakstema/${temakode}/journalposter`;
 
-  const { data: dokumentliste, isLoading } = useSWRImmutable({ path: dokumentlisteUrl }, fetcher, {
-    shouldRetryOnError: false,
-    onError: setIsError,
-  });
+  const { data: dokumentliste, isLoading } = useSWRImmutable(
+    { path: dokumentlisteUrl, handleNotFound: true },
+    fetcher,
+    {
+      shouldRetryOnError: false,
+      onError: setIsError,
+    }
+  );
 
   const { data: fullmaktInfo } = useSWR<FullmaktInfoProps>({ path: getFullmaktInfoUrl }, fetcher, {
     shouldRetryOnError: false,

--- a/src/utils/reloadContentOnPageshow.ts
+++ b/src/utils/reloadContentOnPageshow.ts
@@ -1,0 +1,7 @@
+export const reloadOnPageshow = () => {
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      location.reload();
+    }
+  });
+};


### PR DESCRIPTION
Redirect til innlogging ved 401 fra api
Redirect til landingsside ved 404 på sakstema-side
Tving reload ved navigere på siden, for å unngå at data blir cachet i bfcache